### PR TITLE
Implement `LambdaMocks` Target

### DIFF
--- a/Sources/LambdaMocks/Documentation.docc/LambdaMocks.md
+++ b/Sources/LambdaMocks/Documentation.docc/LambdaMocks.md
@@ -1,0 +1,11 @@
+# ``LambdaMocks``
+
+Helpers for testing LambdaExtras.
+
+## Overview
+
+`LambdaMocks` contains helpers for testing Lambda handlers.
+
+## Topics
+
+### Essentials

--- a/Sources/LambdaMocks/File.swift
+++ b/Sources/LambdaMocks/File.swift
@@ -1,8 +1,0 @@
-//
-//  File.swift
-//  LambdaExtras
-//
-//  Created by Mathew Gacy on 12/15/23.
-//
-
-import Foundation

--- a/Sources/LambdaMocks/MockContext.swift
+++ b/Sources/LambdaMocks/MockContext.swift
@@ -1,0 +1,105 @@
+//
+//  MockContext.swift
+//  LambdaExtras
+//
+//  Created by Mathew Gacy on 12/8/23.
+//
+
+import Dispatch
+import Foundation
+import LambdaExtrasCore
+import Logging
+import NIOCore
+
+/// A mock function context for testing.
+public struct MockContext<E>: RuntimeContext, EnvironmentValueProvider {
+    public var requestID: String
+    public var traceID: String
+    public var invokedFunctionARN: String
+    public var deadline: DispatchWallTime
+    public var cognitoIdentity: String?
+    public var clientContext: String?
+    public var logger: Logger
+    public var eventLoop: EventLoop
+    public var allocator: ByteBufferAllocator
+
+    /// A closure returning the value of the given environment variable.
+    public var environmentValueProvider: @Sendable (E) throws -> String
+
+    /// Creates a new instance.
+    ///
+    /// - Parameters:
+    ///   - requestID: The request ID.
+    ///   - traceID: The tracing header.
+    ///   - invokedFunctionARN: The ARN of the Lambda function.
+    ///   - deadline: The timestamp that the function times out.
+    ///   - cognitoIdentity: The Cognito identity provider ID.
+    ///   - clientContext: Data about the client application and device.
+    ///   - logger: The logger.
+    ///   - eventLoop: The event loop.
+    ///   - allocator: The byte buffer allocator.
+    ///   - environmentValueProvider: A closure returning the value of the given environment
+    ///   variable.
+    public init(
+        requestID: String,
+        traceID: String,
+        invokedFunctionARN: String,
+        deadline: DispatchWallTime,
+        cognitoIdentity: String? = nil,
+        clientContext: String? = nil,
+        logger: Logger,
+        eventLoop: EventLoop,
+        allocator: ByteBufferAllocator,
+        environmentValueProvider: @escaping @Sendable (E) throws -> String
+    ) {
+        self.requestID = requestID
+        self.traceID = traceID
+        self.invokedFunctionARN = invokedFunctionARN
+        self.deadline = deadline
+        self.cognitoIdentity = cognitoIdentity
+        self.clientContext = clientContext
+        self.logger = logger
+        self.eventLoop = eventLoop
+        self.allocator = allocator
+        self.environmentValueProvider = environmentValueProvider
+    }
+
+    public func value(for environmentVariable: E) throws -> String {
+        try environmentValueProvider(environmentVariable)
+    }
+}
+
+public extension MockContext {
+    /// Creates a new instance.
+    ///
+    /// - Parameters:
+    ///   - timeout: The time interval at which the function will time out.
+    ///   - requestID: The request ID.
+    ///   - traceID: The tracing header.
+    ///   - invokedFunctionARN: The ARN of the Lambda function.
+    ///   - eventLoop: The event loop.
+    ///   - allocator: The byte buffer allocator.
+    ///   - environmentValueProvider: A closure returning the value of the given environment
+    ///   variable.
+    init(
+        timeout: DispatchTimeInterval = .seconds(3),
+        requestID: String = UUID().uuidString,
+        traceID: String = "abc123",
+        invokedFunctionARN: String = "aws:arn:",
+        eventLoop: EventLoop,
+        allocator: ByteBufferAllocator = .init(),
+        environmentValueProvider: @escaping @Sendable (E) throws -> String
+    ) {
+        self.requestID = requestID
+        self.traceID = traceID
+        self.invokedFunctionARN = invokedFunctionARN
+        self.deadline = .now() + timeout
+        self.logger = Logger(
+            label: "mock-logger",
+            factory: { _ in StreamLogHandler.standardOutput(label: "mock-logger") }
+        )
+        self.eventLoop = eventLoop
+        self.allocator = allocator
+        self.environmentValueProvider = environmentValueProvider
+    }
+}

--- a/Sources/LambdaMocks/MockInitializationContext.swift
+++ b/Sources/LambdaMocks/MockInitializationContext.swift
@@ -1,0 +1,62 @@
+//
+//  MockInitializationContext.swift
+//  LambdaExtras
+//
+//  Created by Mathew Gacy on 12/14/23.
+//
+
+import Foundation
+import LambdaExtrasCore
+import Logging
+import NIOCore
+
+/// A mock initialization context for testing.
+public class MockInitializationContext<E>: InitializationContext, EnvironmentValueProvider, @unchecked Sendable {
+    public let logger: Logger
+    public let eventLoop: EventLoop
+    public let allocator: ByteBufferAllocator
+
+    /// A collection of closures to be called on shutdown.
+    public var handlers: [(EventLoop) -> EventLoopFuture<Void>] = []
+
+    /// A closure returning the value of the given environment variable.
+    private var environmentValueProvider: @Sendable (E) throws -> String
+
+    /// Creates a new instance.
+    ///
+    /// - Parameters:
+    ///   - logger: The logger.
+    ///   - eventLoop: The event loop.
+    ///   - allocator: The byte buffer allocator.
+    ///   - handlers: Closures to be called on shutdown.
+    ///   - environmentValueProvider: A closure returning the value of the given environment
+    ///   variable.
+    public init(
+        logger: Logger,
+        eventLoop: EventLoop,
+        allocator: ByteBufferAllocator,
+        handlers: [(EventLoop) -> EventLoopFuture<Void>] = [],
+        environmentValueProvider: @escaping @Sendable (E) throws -> String
+    ) {
+        self.logger = logger
+        self.eventLoop = eventLoop
+        self.allocator = allocator
+        self.environmentValueProvider = environmentValueProvider
+        self.handlers = handlers
+    }
+
+    public func handleShutdown(_ handler: @escaping (EventLoop) -> EventLoopFuture<Void>) {
+        handlers.append(handler)
+    }
+
+    public func value(for environmentVariable: E) throws -> String {
+        try environmentValueProvider(environmentVariable)
+    }
+
+    /// Calls the context's shutdown handlers.
+    public func shutdown() {
+        for handler in handlers.reversed() {
+            _ = handler(eventLoop)
+        }
+    }
+}


### PR DESCRIPTION
This implements the `LambdaMocks` target with types conforming to `InitializationContext` (abstracts `LambdaInitializationContext`) and `RuntimeContext` (abstracts `LambdaContext`). This would be used by test target for the handler implementing the core logic of a lambda.