### PR TITLE
Add SwiftLint Plugin

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,4 +1,4 @@
 version: 1
 builder:
   configs:
-    - documentation_targets: [LambdaExtrasCore, LambdaExtras, LambdaMocks]
+    - documentation_targets: [LambdaExtras, LambdaExtrasCore, LambdaMocks]

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,58 @@
+excluded:
+  - .build
+
+opt_in_rules:
+  - empty_count
+  - explicit_init
+  - closure_spacing
+  - overridden_super_call
+  - redundant_nil_coalescing
+  - private_outlet
+  - nimble_operator
+  - attributes
+  - operator_usage_whitespace
+  - closure_end_indentation
+  - first_where
+  - prohibited_super_call
+  - fatal_error_message
+  - vertical_parameter_alignment_on_call
+  - let_var_whitespace
+  - unneeded_parentheses_in_closure_argument
+  - extension_access_modifier
+  - pattern_matching_keywords
+  - array_init
+  - literal_expression_end_indentation
+
+disabled_rules:
+  - void_return
+  - multiple_closures_with_trailing_closure
+  - vertical_parameter_alignment_on_call
+
+identifier_name:
+  excluded:
+    - id
+
+type_name:
+  excluded:
+    - ID
+
+function_body_length: 50
+
+line_length: 200
+
+file_length:
+    warning: 500
+    error: 1000
+
+nesting:
+  type_level:
+    warning: 2
+  function_level:
+    warning: 10
+
+large_tuple:
+  warning: 6
+  error: 10
+
+cyclomatic_complexity:
+  ignores_case_statements: true

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,42 @@
 {
   "pins" : [
     {
+      "identity" : "collectionconcurrencykit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/JohnSundell/CollectionConcurrencyKit.git",
+      "state" : {
+        "revision" : "b4f23e24b5a1bff301efc5e70871083ca029ff95",
+        "version" : "0.2.0"
+      }
+    },
+    {
+      "identity" : "cryptoswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
+      "state" : {
+        "revision" : "db51c407d3be4a051484a141bf0bff36c43d3b1e",
+        "version" : "1.8.0"
+      }
+    },
+    {
+      "identity" : "sourcekitten",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/SourceKitten.git",
+      "state" : {
+        "revision" : "b6dc09ee51dfb0c66e042d2328c017483a1a5d56",
+        "version" : "0.34.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "8f4d2753f0e4778c76d5f05ad16c74f707390531",
+        "version" : "1.2.3"
+      }
+    },
+    {
       "identity" : "swift-atomics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
@@ -52,6 +88,51 @@
       "state" : {
         "revision" : "702cd7c56d5d44eeba73fdf83918339b26dc855c",
         "version" : "2.62.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "6ad4ea24b01559dde0773e3d091f1b9e36175036",
+        "version" : "509.0.2"
+      }
+    },
+    {
+      "identity" : "swiftlint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/SwiftLint.git",
+      "state" : {
+        "revision" : "f17a4f9dfb6a6afb0408426354e4180daaf49cee",
+        "version" : "0.54.0"
+      }
+    },
+    {
+      "identity" : "swiftytexttable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/scottrhoyt/SwiftyTextTable.git",
+      "state" : {
+        "revision" : "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "swxmlhash",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/drmohundro/SWXMLHash.git",
+      "state" : {
+        "revision" : "a853604c9e9a83ad9954c7e3d2a565273982471f",
+        "version" : "7.0.2"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "0d9ee7ea8c4ebd4a489ad7a73d5c6cad55d6fed3",
+        "version" : "5.0.6"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,9 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.4.2")),
         .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.43.1")),
         .package(url: "https://github.com/swift-server/swift-aws-lambda-events.git", branch: "main"),
-        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", branch: "main")
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", branch: "main"),
+        // Plugins
+        .package(url: "https://github.com/realm/SwiftLint.git", exact: "0.54.0")
     ],
     targets: [
         .target(
@@ -25,6 +27,9 @@ let package = Package(
             dependencies: [
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "NIOCore", package: "swift-nio")
+            ],
+            plugins: [
+                .plugin(name: "SwiftLintPlugin", package: "SwiftLint")
             ]
         ),
         .target(
@@ -33,12 +38,18 @@ let package = Package(
                 "LambdaExtrasCore",
                 .product(name: "AWSLambdaRuntime",package: "swift-aws-lambda-runtime"),
                 .product(name: "AWSLambdaEvents", package: "swift-aws-lambda-events")
+            ],
+            plugins: [
+                .plugin(name: "SwiftLintPlugin", package: "SwiftLint")
             ]
         ),
         .target(
             name: "LambdaMocks",
             dependencies: [
                 "LambdaExtrasCore"
+            ],
+            plugins: [
+                .plugin(name: "SwiftLintPlugin", package: "SwiftLint")
             ]
         ),
         .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -17,41 +17,9 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.4.2")),
         .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.43.1")),
         .package(url: "https://github.com/swift-server/swift-aws-lambda-events.git", branch: "main"),
-        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", branch: "main"),
-        // Plugins
-        .package(url: "https://github.com/realm/SwiftLint.git", exact: "0.54.0")
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", branch: "main")
     ],
     targets: [
-        .target(
-            name: "LambdaExtrasCore",
-            dependencies: [
-                .product(name: "Logging", package: "swift-log"),
-                .product(name: "NIOCore", package: "swift-nio")
-            ],
-            plugins: [
-                .plugin(name: "SwiftLintPlugin", package: "SwiftLint")
-            ]
-        ),
-        .target(
-            name: "LambdaExtras",
-            dependencies: [
-                "LambdaExtrasCore",
-                .product(name: "AWSLambdaRuntime",package: "swift-aws-lambda-runtime"),
-                .product(name: "AWSLambdaEvents", package: "swift-aws-lambda-events")
-            ],
-            plugins: [
-                .plugin(name: "SwiftLintPlugin", package: "SwiftLint")
-            ]
-        ),
-        .target(
-            name: "LambdaMocks",
-            dependencies: [
-                "LambdaExtrasCore"
-            ],
-            plugins: [
-                .plugin(name: "SwiftLintPlugin", package: "SwiftLint")
-            ]
-        ),
         .testTarget(
             name: "LambdaExtrasTests",
             dependencies: [
@@ -60,3 +28,36 @@ let package = Package(
         )
     ]
 )
+
+let genericTargets: [Target] = [
+    .target(
+        name: "LambdaExtrasCore",
+        dependencies: [
+            .product(name: "Logging", package: "swift-log"),
+            .product(name: "NIOCore", package: "swift-nio")
+        ]
+    ),
+    .target(
+        name: "LambdaExtras",
+        dependencies: [
+            "LambdaExtrasCore",
+            .product(name: "AWSLambdaRuntime",package: "swift-aws-lambda-runtime"),
+            .product(name: "AWSLambdaEvents", package: "swift-aws-lambda-events")
+        ]
+    ),
+    .target(
+        name: "LambdaMocks",
+        dependencies: [
+            "LambdaExtrasCore"
+        ]
+    )
+]
+
+#if os(macOS)
+package.dependencies.append(.package(url: "https://github.com/realm/SwiftLint.git", exact: "0.54.0"))
+for target in genericTargets {
+    target.plugins = [.plugin(name: "SwiftLintPlugin", package: "SwiftLint")]
+}
+#endif
+
+package.targets.append(contentsOf: genericTargets)

--- a/Sources/LambdaExtrasCore/Protocols/InitializationContext.swift
+++ b/Sources/LambdaExtrasCore/Protocols/InitializationContext.swift
@@ -23,8 +23,6 @@ public protocol InitializationContext: Sendable {
     /// `ByteBufferAllocator` to allocate `ByteBuffer`.
     var allocator: ByteBufferAllocator { get }
 
-    // TODO: Is there any point to allowing a name to be passed?
-
     /// Register a closure to be performed on lambda shutdown.
     ///
     /// - Parameter handler: A closure to execute when the lambda shuts down.


### PR DESCRIPTION
Adds SwiftLint as a dependency and uses its package plugin.

IIRC, this caused issues previously due to SwiftLint's specification of an untstable version of a dependency, which prevented the specification of a stable version of any package that depended on it. Version `0.54.0` (and probably before) only specifies stable versions. Moreover, that wouldn't be an issue for this package anyway as we specify an unstable version of `swift-aws-lambda-runtime` since the last release was nearly a year ago despite significant changes since.

Building this with the plugin fails on Linux, presumably because the artifact bundle specified by the plugin only supports macOS. As a result, the plugin is only added to the generic targets when built on macOS.