### PR TITLE
`LambdaCoding` Changes and Tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,18 +18,10 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.43.1")),
         .package(url: "https://github.com/swift-server/swift-aws-lambda-events.git", branch: "main"),
         .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", branch: "main")
-    ],
-    targets: [
-        .testTarget(
-            name: "LambdaExtrasTests",
-            dependencies: [
-                "LambdaExtras"
-            ]
-        )
     ]
 )
 
-let genericTargets: [Target] = [
+let targets: [Target] = [
     .target(
         name: "LambdaExtrasCore",
         dependencies: [
@@ -50,14 +42,21 @@ let genericTargets: [Target] = [
         dependencies: [
             "LambdaExtrasCore"
         ]
+    ),
+    .testTarget(
+        name: "LambdaExtrasTests",
+        dependencies: [
+            "LambdaExtras",
+            "LambdaMocks"
+        ]
     )
 ]
 
 #if os(macOS)
 package.dependencies.append(.package(url: "https://github.com/realm/SwiftLint.git", exact: "0.54.0"))
-for target in genericTargets {
+for target in targets {
     target.plugins = [.plugin(name: "SwiftLintPlugin", package: "SwiftLint")]
 }
 #endif
 
-package.targets.append(contentsOf: genericTargets)
+package.targets = targets

--- a/Sources/LambdaExtrasCore/Extensions.swift
+++ b/Sources/LambdaExtrasCore/Extensions.swift
@@ -51,6 +51,21 @@ public extension JSONDecoder {
     }
 }
 
+public extension JSONSerialization {
+    /// Returns an escaped string for the given JSON object data.
+    ///
+    /// - Parameters:
+    ///   - jsonData: The data from which to generate the JSON string.
+    ///   - options: Options for creating the JSON data.
+    /// - Returns: An escaped string representation of the given object `jsonData`.
+    static func escapedString(with jsonData: Data, options: WritingOptions = []) throws -> String {
+        let jsonString = String(decoding: jsonData, as: UTF8.self)
+        let data = try data(withJSONObject: [jsonString], options: options)
+        let encodedString = String(decoding: data, as: UTF8.self)
+        return String(encodedString.dropLast().dropFirst())
+    }
+}
+
 public extension Optional {
     /// Convienence method to `throw` if an optional type has a `nil` value.
     ///

--- a/Sources/LambdaExtrasCore/HandlerError.swift
+++ b/Sources/LambdaExtrasCore/HandlerError.swift
@@ -14,7 +14,7 @@ public enum HandlerError: Error, Equatable, LocalizedError {
     /// The lambda context is missing an expected environment variable.
     case envError(String)
     /// A custom error.
-    case custom(_ message: String?)
+    case custom(_ message: String)
 
     /// Retrieve the description for this error.
     public var errorDescription: String? {
@@ -24,7 +24,7 @@ public enum HandlerError: Error, Equatable, LocalizedError {
         case .envError(let variable):
             return "The environment does not contain the expected variable `\(variable)`."
         case .custom(let message):
-            return message ?? "Unknown error."
+            return message
         }
     }
 }

--- a/Sources/LambdaExtrasCore/Protocols/LambdaCoding.swift
+++ b/Sources/LambdaExtrasCore/Protocols/LambdaCoding.swift
@@ -25,7 +25,7 @@ public protocol LambdaCoding<Event, Output, UnderlyingEvent, UnderlyingOutput> {
     ///
     /// - Parameter event: The event to encode.
     /// - Returns: An underlying event.
-    func decode(event: Event) async throws -> UnderlyingEvent
+    func decode(event: Event) throws -> UnderlyingEvent
 
     /// Encodes the given output to that of a lambda.
     ///

--- a/Sources/LambdaMocks/APIGatewayV2+Utils.swift
+++ b/Sources/LambdaMocks/APIGatewayV2+Utils.swift
@@ -1,0 +1,228 @@
+//
+//  APIGatewayV2+Utils.swift
+//  LambdaExtras
+//
+//  Created by Mathew Gacy on 12/29/23.
+//
+
+import AWSLambdaEvents
+import Foundation
+
+// MARK: - Helpers
+
+fileprivate extension String {
+    func quoted() -> String {
+        "\"\(self)\""
+    }
+}
+
+fileprivate extension Array<String> {
+    mutating func appendJSON(key: String, value: String) {
+        append("\(key.quoted()): \(value)")
+    }
+
+    func jsonString() -> String {
+        "[\(self.map { $0.quoted() }.joined(separator: ", "))]"
+    }
+}
+
+fileprivate extension Dictionary<String, String> {
+    func jsonString(serializationOptions options: JSONSerialization.WritingOptions = []) throws -> String {
+        String(
+            decoding: try JSONSerialization.data(withJSONObject: self, options: options),
+            as: UTF8.self)
+    }
+}
+
+// MARK: - Request
+
+public extension APIGatewayV2Request {
+    /// Returns a mock request with the given values.
+    ///
+    /// - Parameters:
+    ///   - bodyValue: The value to be used as the request body.
+    ///   - encoder: The encoder used to encode the `bodyValue`.
+    ///   - method: The HTTP method.
+    ///   - rawPath: The raw path.
+    ///   - cookies: The cookies.
+    ///   - headers: The headers.
+    ///   - parameters: The parameters.
+    ///   - pathParameters: The path parameters.
+    ///   - isBase64Encoded: Whether the body uses Base64 encoding.
+    /// - Returns: The mock request.
+    static func mock<T: Encodable>(
+        _ bodyValue: T,
+        encodedWith encoder: JSONEncoder = .init(),
+        method: HTTPMethod = .POST,
+        rawPath: String = "/endpoint",
+        cookies: [String]? = nil,
+        headers: [String: String] = [:],
+        parameters: [String: String]? = nil,
+        pathParameters: [String: String]? = nil,
+        isBase64Encoded: Bool = false
+    ) throws -> Self {
+        try mock(
+            method: method,
+            rawPath: rawPath,
+            cookies: cookies,
+            headers: headers,
+            parameters: parameters,
+            pathParameters: pathParameters,
+            body: try JSONSerialization.escapedString(
+                with: try encoder.encode(bodyValue))
+            )
+    }
+
+    /// Returns a mock request with the given values.
+    ///
+    /// - Parameters:
+    ///   - method: The HTTP method.
+    ///   - rawPath: The raw path.
+    ///   - cookies: The cookies.
+    ///   - headers: The headers.
+    ///   - parameters: The parameters.
+    ///   - pathParameters: The path parameters.
+    ///   - isBase64Encoded: Whether the body uses Base64 encoding.
+    ///   - body: The body.
+    /// - Returns: The mock request.
+    static func mock(
+        // swiftlint:disable:previous function_body_length
+        method: HTTPMethod = .POST,
+        rawPath: String = "/endpoint",
+        cookies: [String]? = nil,
+        headers: [String: String] = [:],
+        parameters: [String: String]? = nil,
+        pathParameters: [String: String]? = nil,
+        isBase64Encoded: Bool = false,
+        // stageVariables: [String: String]? = nil,
+        body: String? = nil
+    ) throws -> Self {
+        var rawQueryString = "".quoted()
+        var elements: [String] = []
+        if let cookies {
+            elements.appendJSON(key: "cookies", value: cookies.jsonString())
+        }
+        elements.appendJSON(key: "headers", value: try headers.jsonString())
+
+        if let parameters {
+            elements.appendJSON(key: "queryStringParameters", value: try parameters.jsonString())
+            rawQueryString = parameters
+                .compactMap { key, value in
+                    "\(key)=\(value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? value)"
+                }
+                .joined(separator: "&")
+                .quoted()
+        }
+        elements.appendJSON(key: "rawQueryString", value: rawQueryString)
+
+        if let pathParameters {
+            elements.appendJSON(key: "pathParameters", value: try pathParameters.jsonString())
+        }
+
+        if var body {
+            if isBase64Encoded {
+                body = Data(body.utf8).base64EncodedString()
+            }
+            elements.appendJSON(key: "body", value: body)
+        }
+
+        let additionalJSON = elements.map { "  \($0)" }
+            .joined(separator: ",\n")
+
+        // https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
+        let jsonString = """
+            {
+              "version": "2.0",
+              "routeKey": "$default",
+              "rawPath": "\(rawPath)",
+            \(additionalJSON),
+              "requestContext": {
+                "accountId": "123456789012",
+                "apiId": "api-id",
+                "authentication": {
+                  "clientCert": {
+                    "clientCertPem": "CERT_CONTENT",
+                    "subjectDN": "www.example.com",
+                    "issuerDN": "Example issuer",
+                    "serialNumber": "a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1",
+                    "validity": {
+                      "notBefore": "May 28 12:30:02 2019 GMT",
+                      "notAfter": "Aug  5 09:36:04 2021 GMT"
+                    }
+                  }
+                },
+                "authorizer": {
+                  "jwt": {
+                    "claims": {
+                      "claim1": "value1",
+                      "claim2": "value2"
+                    },
+                    "scopes": [
+                      "scope1",
+                      "scope2"
+                    ]
+                  }
+                },
+                "domainName": "id.execute-api.us-east-1.amazonaws.com",
+                "domainPrefix": "id",
+                "http": {
+                  "method": "\(method.rawValue)",
+                  "path": "/path/to/resource",
+                  "protocol": "HTTP/1.1",
+                  "sourceIp": "192.168.0.1/32",
+                  "userAgent": "agent"
+                },
+                "requestId": "id",
+                "routeKey": "$default",
+                "stage": "$default",
+                "time": "12/Mar/2020:19:03:58 +0000",
+                "timeEpoch": 1583348638390
+              },
+              "isBase64Encoded": \(isBase64Encoded),
+              "stageVariables": {
+                "stageVariable1": "value1",
+                "stageVariable2": "value2"
+              }
+            }
+            """
+
+        return try JSONDecoder().decode(
+            APIGatewayV2Request.self,
+            from: jsonString)
+    }
+}
+
+// MARK: - Response
+
+public extension APIGatewayV2Response {
+    /// Returns a mocked response with the given values.
+    /// - Parameters:
+    ///   - bodyValue: The value to be used as the request body.
+    ///   - encoder: The encoder used to encode the `bodyValue`.
+    ///   - statusCode: The status code.
+    ///   - headers: The headers.
+    ///   - isBase64Encoded: Whether the body uses Base64 encoding.
+    ///   - cookies: The cookies.
+    /// - Returns: The response.
+    static func mock<T: Encodable>(
+        _ bodyValue: T,
+        encodedWith encoder: JSONEncoder = .init(),
+        statusCode: HTTPResponseStatus = .ok,
+        headers: [String: String]? = nil,
+        isBase64Encoded: Bool = false,
+        cookies: [String]? = nil
+    ) throws -> Self {
+        var body = try JSONSerialization.escapedString(
+            with: try encoder.encode(bodyValue))
+        if isBase64Encoded {
+            body = Data(body.utf8).base64EncodedString()
+        }
+
+        return APIGatewayV2Response(
+            statusCode: statusCode,
+            headers: headers,
+            body: body,
+            isBase64Encoded: isBase64Encoded,
+            cookies: cookies)
+    }
+}

--- a/Tests/LambdaExtrasTests/APIGatewayCoderTests.swift
+++ b/Tests/LambdaExtrasTests/APIGatewayCoderTests.swift
@@ -1,0 +1,135 @@
+//
+//  APIGatewayCoderTests.swift
+//  LambdaExtras
+//
+//  Created by Mathew Gacy on 12/28/23.
+//
+
+@testable import LambdaExtras
+@testable import LambdaExtrasCore
+import AWSLambdaEvents
+import Foundation
+import LambdaMocks
+import XCTest
+
+final class APIGatewayCoderTests: XCTestCase {}
+
+// MARK: - Decode Event
+extension APIGatewayCoderTests {
+    func testDecode() async throws {
+        let body = """
+            "{\\"int\\":1,\\"string\\":\\"one\\"}"
+            """
+        let request = try APIGatewayV2Request.mock(body: body)
+
+        let sut = APIGatewayCoder<TestModel, String>()
+        let actual = try sut.decode(event: request)
+
+        XCTAssertEqual(actual, Mock.testModel)
+    }
+
+    func testDecodeEmptyBodyThrows() throws {
+        let sut = APIGatewayCoder<TestModel, String>()
+        let request = try APIGatewayV2Request.mock()
+
+        XCTAssertThrows(try sut.decode(event: request), HandlerError.emptyBody)
+    }
+}
+
+// MARK: - Encode Output
+extension APIGatewayCoderTests {
+    func testEncodeEventWithDefaultBody() throws {
+        let sut = APIGatewayCoder<TestModel, TestModel>()
+        let actual = try sut.encode(output: Mock.testModel)
+
+        XCTAssertEqual(actual.statusCode, .ok)
+        XCTAssertNil(actual.body)
+    }
+
+    func testEncodeEvent() throws {
+        let expectedBody = """
+            "{\\"int\\":1,\\"string\\":\\"one\\"}"
+            """
+
+        let sut = APIGatewayCoder<TestModel, TestModel>(
+            responseBody: { model in
+                try JSONSerialization.escapedString(with: JSONEncoder().encode(model))
+            }
+        )
+        let actual = try sut.encode(output: Mock.testModel)
+
+        XCTAssertEqual(actual.statusCode, .ok)
+        XCTAssertEqual(actual.body, expectedBody)
+    }
+}
+
+// MARK: - Encode Error
+extension APIGatewayCoderTests {
+    func testEncodeEmptyBodyError() throws {
+        let expectedStatus: HTTPResponseStatus = .badRequest
+        let expectedBody = "The AWS event did not contain a body."
+
+        let sut = APIGatewayCoder<TestModel, String>()
+        let actual = try sut.encode(error: HandlerError.emptyBody)
+
+        XCTAssertEqual(actual.statusCode, expectedStatus)
+        XCTAssertEqual(actual.body, expectedBody)
+    }
+
+    func testEncodeEnvironmentError() throws {
+        let variableName = "MY_ENV_VARIABLE"
+
+        let expectedStatus = HTTPResponseStatus.internalServerError
+        let expectedBody = "The environment does not contain the expected variable `\(variableName)`."
+
+        let sut = APIGatewayCoder<TestModel, String>()
+        let actual = try sut.encode(error: HandlerError.envError(variableName))
+
+        XCTAssertEqual(actual.statusCode, expectedStatus)
+        XCTAssertEqual(actual.body, expectedBody)
+    }
+
+    func testEncodeCustomError() throws {
+        let expectedStatus = HTTPResponseStatus.internalServerError
+        let expectedBody = "My error message"
+
+        let sut = APIGatewayCoder<TestModel, String>()
+        let actual = try sut.encode(error: HandlerError.custom(expectedBody))
+
+        XCTAssertEqual(actual.statusCode, expectedStatus)
+        XCTAssertEqual(actual.body, expectedBody)
+    }
+
+    func testEncodeError() throws {
+        struct TestError: LocalizedError {
+            var errorDescription: String? { "Oops, something went wrong" }
+        }
+
+        let expectedStatus = HTTPResponseStatus.internalServerError
+        let expectedBody = "Oops, something went wrong"
+
+        let sut = APIGatewayCoder<TestModel, String>()
+        let actual = try sut.encode(error: TestError())
+
+        XCTAssertEqual(actual.statusCode, expectedStatus)
+        XCTAssertEqual(actual.body, expectedBody)
+    }
+
+    func testEncodeCustomizedError() throws {
+        let expectedStatus = HTTPResponseStatus.internalServerError
+        let expectedBody = """
+            "{\\"reason\\":\\"Oops, something went wrong\\"}"
+            """
+
+        let sut = APIGatewayCoder<TestModel, String>(
+            errorBody: { error in
+                """
+                "{\\"reason\\":\\"\(error.localizedDescription)\\"}"
+                """
+            })
+        let actual = try sut.encode(error: HandlerError.custom("Oops, something went wrong"))
+
+        XCTAssertEqual(actual.statusCode, expectedStatus)
+        XCTAssertEqual(actual.body, expectedBody)
+    }
+}

--- a/Tests/LambdaExtrasTests/Support/Helpers.swift
+++ b/Tests/LambdaExtrasTests/Support/Helpers.swift
@@ -1,0 +1,45 @@
+//
+//  Helpers.swift
+//  LambdaExtras
+//
+//  Created by Mathew Gacy on 12/29/23.
+//
+
+import Foundation
+import XCTest
+
+extension XCTest {
+    /// Asserts than an expression throws a given error.
+    ///
+    /// - Parameters:
+    ///   - expression: An expression that can throw an error.
+    ///   - expectedError: The expected error value.
+    ///   - message: An optional description of a failure.
+    ///   - file: The file where the failure occurs. The default is the filename of the test case
+    ///   where you call this function.
+    ///   - line: The line number where the failure occurs. The default is the line number where you
+    ///   call this function.
+    func XCTAssertThrows<T, E: Error & Equatable>(
+        _ expression: @autoclosure () throws -> T,
+        _ expectedError: E,
+        _ message: @autoclosure () -> String = "",
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertThrowsError(
+            try expression(),
+            message(),
+            file: file,
+            line: line
+        ) { error in
+            if let typedError = error as? E {
+                XCTAssertEqual(typedError, expectedError, file: file, line: line)
+            } else {
+                XCTFail(
+                    "The thrown error (\"\(type(of: error))\") was not the expected type (\"\(E.self)\")",
+                    file: file,
+                    line: line)
+            }
+        }
+    }
+}

--- a/Tests/LambdaExtrasTests/Support/Mock.swift
+++ b/Tests/LambdaExtrasTests/Support/Mock.swift
@@ -1,0 +1,24 @@
+//
+//  Mock.swift
+//  LambdaExtras
+//
+//  Created by Mathew Gacy on 12/29/23.
+//
+
+import Foundation
+
+struct TestModel: Codable, Equatable, Sendable {
+    var int: Int
+    var string: String
+}
+
+enum Mock {
+    static var testModel: TestModel {
+        // swiftlint:disable:next force_try
+        try! JSONDecoder().decode(TestModel.self, from: testModelJSON)
+    }
+
+    static let testModelJSON = """
+        {"int":1,"string":"one"}
+        """
+}


### PR DESCRIPTION
## `LambdaCoding` Changes

- make `LambdaCoding.decode(event:)` synchronous

## `APIGatewayCoder` Changes

- add `errorBodyProvider` member
- return a simple string as the default error body

## Additional Changes

- Make the associated value for `HandlerError.custom` non-optional
- Lint test targets as well as generic ones