### PR TITLE
Fix Build Error

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,6 +41,7 @@ let targets: [Target] = [
         name: "LambdaMocks",
         dependencies: [
             "LambdaExtrasCore",
+            .product(name: "AWSLambdaEvents", package: "swift-aws-lambda-events"),
             .product(name: "NIO", package: "swift-nio")
         ]
     ),


### PR DESCRIPTION
Fixes a build error in targets specifying `LambdaMocks` as a dependency.