### PR TITLE
Strict Concurrency Support

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,26 @@
+name: Run Danger
+on:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+jobs:
+  build:
+    if: github.event.pull_request.draft == false
+    name: Run Danger
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
+      - name: Danger
+        uses: 417-72KI/danger-swiftlint@v5.9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -2,31 +2,31 @@ excluded:
   - .build
 
 opt_in_rules:
+  - array_init
+  - attributes
+  - closure_end_indentation
+  - closure_spacing
   - empty_count
   - explicit_init
-  - closure_spacing
-  - overridden_super_call
-  - redundant_nil_coalescing
-  - private_outlet
-  - nimble_operator
-  - attributes
-  - operator_usage_whitespace
-  - closure_end_indentation
-  - first_where
-  - prohibited_super_call
-  - fatal_error_message
-  - vertical_parameter_alignment_on_call
-  - let_var_whitespace
-  - unneeded_parentheses_in_closure_argument
   - extension_access_modifier
-  - pattern_matching_keywords
-  - array_init
+  - fatal_error_message
+  - first_where
+  - let_var_whitespace
   - literal_expression_end_indentation
+  - nimble_operator
+  - operator_usage_whitespace
+  - overridden_super_call
+  - pattern_matching_keywords
+  - private_outlet
+  - prohibited_super_call
+  - redundant_nil_coalescing
+  - unneeded_parentheses_in_closure_argument
+  - vertical_parameter_alignment_on_call
 
 disabled_rules:
-  - void_return
   - multiple_closures_with_trailing_closure
   - vertical_parameter_alignment_on_call
+  - void_return
 
 identifier_name:
   excluded:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -25,6 +25,7 @@ opt_in_rules:
 
 disabled_rules:
   - multiple_closures_with_trailing_closure
+  - optional_data_string_conversion
   - vertical_parameter_alignment_on_call
   - void_return
 

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -1,0 +1,15 @@
+import Danger
+
+extension String: Error {}
+
+let danger = Danger()
+
+if danger.github.pullRequest.body == nil {
+    danger.fail("Please add a description to this Pull Request")
+}
+
+SwiftLint
+    .lint(
+        .all(directory: nil),
+        configFile: ".swiftlint.yml"
+    )

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,42 +1,6 @@
 {
   "pins" : [
     {
-      "identity" : "collectionconcurrencykit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/JohnSundell/CollectionConcurrencyKit.git",
-      "state" : {
-        "revision" : "b4f23e24b5a1bff301efc5e70871083ca029ff95",
-        "version" : "0.2.0"
-      }
-    },
-    {
-      "identity" : "cryptoswift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
-      "state" : {
-        "revision" : "db51c407d3be4a051484a141bf0bff36c43d3b1e",
-        "version" : "1.8.0"
-      }
-    },
-    {
-      "identity" : "sourcekitten",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jpsim/SourceKitten.git",
-      "state" : {
-        "revision" : "b6dc09ee51dfb0c66e042d2328c017483a1a5d56",
-        "version" : "0.34.1"
-      }
-    },
-    {
-      "identity" : "swift-argument-parser",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser.git",
-      "state" : {
-        "revision" : "8f4d2753f0e4778c76d5f05ad16c74f707390531",
-        "version" : "1.2.3"
-      }
-    },
-    {
       "identity" : "swift-atomics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
@@ -88,51 +52,6 @@
       "state" : {
         "revision" : "702cd7c56d5d44eeba73fdf83918339b26dc855c",
         "version" : "2.62.0"
-      }
-    },
-    {
-      "identity" : "swift-syntax",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
-      "state" : {
-        "revision" : "6ad4ea24b01559dde0773e3d091f1b9e36175036",
-        "version" : "509.0.2"
-      }
-    },
-    {
-      "identity" : "swiftlint",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/realm/SwiftLint.git",
-      "state" : {
-        "revision" : "f17a4f9dfb6a6afb0408426354e4180daaf49cee",
-        "version" : "0.54.0"
-      }
-    },
-    {
-      "identity" : "swiftytexttable",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/scottrhoyt/SwiftyTextTable.git",
-      "state" : {
-        "revision" : "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
-        "version" : "0.9.0"
-      }
-    },
-    {
-      "identity" : "swxmlhash",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/drmohundro/SWXMLHash.git",
-      "state" : {
-        "revision" : "a853604c9e9a83ad9954c7e3d2a565273982471f",
-        "version" : "7.0.2"
-      }
-    },
-    {
-      "identity" : "yams",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jpsim/Yams.git",
-      "state" : {
-        "revision" : "0d9ee7ea8c4ebd4a489ad7a73d5c6cad55d6fed3",
-        "version" : "5.0.6"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/swift-aws-lambda-events",
       "state" : {
-        "revision" : "997094fe7c55762c07179419a1686230dfa13bef",
-        "version" : "0.2.0"
+        "revision" : "a0b64e9d0d5de872169ef645fda2e33575ee42d0",
+        "version" : "0.4.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/swift-aws-lambda-runtime.git",
       "state" : {
-        "revision" : "8d9f44b7838750b103ad2ad49055e8333d719e8a",
-        "version" : "1.0.0-alpha.2"
+        "revision" : "5ecc24fa54e61756fe7a7a01f2451da1cffa916e",
+        "version" : "1.0.0-alpha.3"
       }
     },
     {
@@ -37,12 +37,21 @@
       }
     },
     {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "ae67c8178eb46944fd85e4dc6dd970e1f3ed6ccd",
+        "version" : "1.3.0"
+      }
+    },
+    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "532d8b529501fb73a2455b179e0bbb6d49b652ed",
-        "version" : "1.5.3"
+        "revision" : "9cb486020ebf03bfa5b5df985387a14a98744537",
+        "version" : "1.6.1"
       }
     },
     {
@@ -50,8 +59,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "702cd7c56d5d44eeba73fdf83918339b26dc855c",
-        "version" : "2.62.0"
+        "revision" : "f7dc3f527576c398709b017584392fb58592e7f5",
+        "version" : "2.75.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "c8a44d836fe7913603e246acab7c528c2e780168",
+        "version" : "1.4.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -14,10 +14,10 @@ let package = Package(
         .library(name: "LambdaMocks", targets: ["LambdaMocks"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.4.2")),
-        .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.43.1")),
-        .package(url: "https://github.com/swift-server/swift-aws-lambda-events.git", .upToNextMajor(from: "0.2.0")),
-        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", "1.0.0-alpha.1"..<"1.0.0-beta.999")
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.4.2"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.43.1"),
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-events", from: "0.2.0"),
+        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime", from: "1.0.0-alpha.3")
     ]
 )
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -54,11 +54,8 @@ let targets: [Target] = [
     )
 ]
 
-#if os(macOS)
-package.dependencies.append(.package(url: "https://github.com/realm/SwiftLint.git", from: "0.54.0"))
 for target in targets {
-    target.plugins = [.plugin(name: "SwiftLintPlugin", package: "SwiftLint")]
+    target.swiftSettings = [.enableExperimentalFeature("StrictConcurrency")]
 }
-#endif
 
 package.targets = targets

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let targets: [Target] = [
         name: "LambdaExtras",
         dependencies: [
             "LambdaExtrasCore",
-            .product(name: "AWSLambdaRuntime",package: "swift-aws-lambda-runtime"),
+            .product(name: "AWSLambdaRuntime", package: "swift-aws-lambda-runtime"),
             .product(name: "AWSLambdaEvents", package: "swift-aws-lambda-events")
         ]
     ),

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Where `<product>` is one of the following:
 
 This package is intended to support the creation of lambdas composed of 2 parts:
 
-- a generic target with a handler implementing the core logic without AWS dependencies
-- an executable target using that generic one
+- a regular target with a handler implementing the core logic without AWS dependencies
+- an executable target using that regular one
 
 ### Handler
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Swifty helpers for working with AWS Lambda.
 
 ## 📱 Requirements
 
-Swift 5.7 toolchain with Swift Package Manager.
+Swift 5.9 toolchain with Swift Package Manager.
 
 ## 🖥 Installation
 

--- a/Sources/LambdaExtras/APIGatewayCoder.swift
+++ b/Sources/LambdaExtras/APIGatewayCoder.swift
@@ -12,7 +12,7 @@ import HTTPTypes
 import LambdaExtrasCore
 
 /// A coder for APIGateway events.
-public struct APIGatewayCoder<E, O>: LambdaCoding where E: Codable, E: Sendable, O: Sendable {
+public struct APIGatewayCoder<E, O>: LambdaCoding, Sendable where E: Codable, E: Sendable, O: Sendable {
     /// A JSON decoder.
     let decoder: JSONDecoder
 

--- a/Sources/LambdaExtras/APIGatewayCoder.swift
+++ b/Sources/LambdaExtras/APIGatewayCoder.swift
@@ -8,6 +8,7 @@
 import AWSLambdaEvents
 import AWSLambdaRuntime
 import Foundation
+import HTTPTypes
 import LambdaExtrasCore
 
 /// A coder for APIGateway events.
@@ -52,16 +53,16 @@ public struct APIGatewayCoder<E, O>: LambdaCoding where E: Codable, E: Sendable,
     }
 
     public func encode(error: Error) throws -> APIGatewayV2Response {
-        let statusCode: HTTPResponseStatus
+        let status: HTTPResponse.Status
         switch error {
         case HandlerError.emptyBody:
-            statusCode = .badRequest
+            status = .badRequest
         default:
-            statusCode = .internalServerError
+            status = .internalServerError
         }
 
         return APIGatewayV2Response(
-            statusCode: statusCode,
+            statusCode: status,
             body: try errorBodyProvider(error.localizedDescription))
     }
 }

--- a/Sources/LambdaExtrasCore/Extensions.swift
+++ b/Sources/LambdaExtrasCore/Extensions.swift
@@ -79,8 +79,7 @@ public extension Optional {
     }
 }
 
-extension String: @retroactive Error {}
-extension String: @retroactive LocalizedError {
+extension Swift.String: Foundation.LocalizedError {
     public var errorDescription: String? { self }
     public var failureReason: String? { self }
 }

--- a/Sources/LambdaExtrasCore/Extensions.swift
+++ b/Sources/LambdaExtrasCore/Extensions.swift
@@ -79,7 +79,8 @@ public extension Optional {
     }
 }
 
-extension String: LocalizedError {
+extension String: @retroactive Error {}
+extension String: @retroactive LocalizedError {
     public var errorDescription: String? { self }
     public var failureReason: String? { self }
 }

--- a/Sources/LambdaExtrasCore/HandlerError.swift
+++ b/Sources/LambdaExtrasCore/HandlerError.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// An error that occurs during lambda handler execution.
-public enum HandlerError: Error, Equatable, LocalizedError {
+public enum HandlerError: Error, Equatable, LocalizedError, Sendable {
     /// The request is missing a body.
     case emptyBody
     /// The lambda context is missing an expected environment variable.

--- a/Sources/LambdaMocks/Extensions/APIGatewayV2+Utils.swift
+++ b/Sources/LambdaMocks/Extensions/APIGatewayV2+Utils.swift
@@ -7,6 +7,7 @@
 
 import AWSLambdaEvents
 import Foundation
+import HTTPTypes
 
 // MARK: - Helpers
 
@@ -53,7 +54,7 @@ public extension APIGatewayV2Request {
     static func mock<T: Encodable>(
         _ bodyValue: T,
         encodedWith encoder: JSONEncoder = .init(),
-        method: HTTPMethod = .POST,
+        method: HTTPRequest.Method = .post,
         rawPath: String = "/endpoint",
         cookies: [String]? = nil,
         headers: [String: String] = [:],
@@ -87,7 +88,7 @@ public extension APIGatewayV2Request {
     /// - Returns: The mock request.
     static func mock(
         // swiftlint:disable:previous function_body_length
-        method: HTTPMethod = .POST,
+        method: HTTPRequest.Method = .post,
         rawPath: String = "/endpoint",
         cookies: [String]? = nil,
         headers: [String: String] = [:],
@@ -206,7 +207,7 @@ public extension APIGatewayV2Response {
     static func mock<T: Encodable>(
         _ bodyValue: T,
         encodedWith encoder: JSONEncoder = .init(),
-        statusCode: HTTPResponseStatus = .ok,
+        statusCode: HTTPResponse.Status = .ok,
         headers: [String: String]? = nil,
         isBase64Encoded: Bool = false,
         cookies: [String]? = nil

--- a/Tests/LambdaExtrasTests/APIGatewayCoderTests.swift
+++ b/Tests/LambdaExtrasTests/APIGatewayCoderTests.swift
@@ -9,6 +9,7 @@
 @testable import LambdaExtrasCore
 import AWSLambdaEvents
 import Foundation
+import HTTPTypes
 import LambdaMocks
 import XCTest
 
@@ -69,7 +70,7 @@ extension APIGatewayCoderTests {
 // MARK: - Encode Error
 extension APIGatewayCoderTests {
     func testEncodeEmptyBodyError() throws {
-        let expectedStatus: HTTPResponseStatus = .badRequest
+        let expectedStatus: HTTPResponse.Status = .badRequest
         let expectedBody = "The AWS event did not contain a body."
 
         let sut = APIGatewayCoder<TestModel, String>()
@@ -82,7 +83,7 @@ extension APIGatewayCoderTests {
     func testEncodeEnvironmentError() throws {
         let variableName = "MY_ENV_VARIABLE"
 
-        let expectedStatus = HTTPResponseStatus.internalServerError
+        let expectedStatus = HTTPResponse.Status.internalServerError
         let expectedBody = "The environment does not contain the expected variable `\(variableName)`."
 
         let sut = APIGatewayCoder<TestModel, String>()
@@ -93,7 +94,7 @@ extension APIGatewayCoderTests {
     }
 
     func testEncodeCustomError() throws {
-        let expectedStatus = HTTPResponseStatus.internalServerError
+        let expectedStatus = HTTPResponse.Status.internalServerError
         let expectedBody = "My error message"
 
         let sut = APIGatewayCoder<TestModel, String>()
@@ -108,7 +109,7 @@ extension APIGatewayCoderTests {
             var errorDescription: String? { "Oops, something went wrong" }
         }
 
-        let expectedStatus = HTTPResponseStatus.internalServerError
+        let expectedStatus = HTTPResponse.Status.internalServerError
         let expectedBody = "Oops, something went wrong"
 
         let sut = APIGatewayCoder<TestModel, String>()
@@ -119,7 +120,7 @@ extension APIGatewayCoderTests {
     }
 
     func testEncodeCustomizedError() throws {
-        let expectedStatus = HTTPResponseStatus.internalServerError
+        let expectedStatus = HTTPResponse.Status.internalServerError
         let expectedBody = """
             "{\\"reason\\":\\"Oops, something went wrong\\"}"
             """


### PR DESCRIPTION
- Enables strict concurrency checking
- Updates dependencies
    - Note that swift-aws-lambda-events v 0.3.0 dropped its custom implementation of HTTP types in favor of the standard [Swift HTTP Type](https://github.com/apple/swift-http-types) project.

###  Other

- Removes the SwiftLint plugin dependency and instead uses a workflow with the [`danger-swiftlint`](https://github.com/417-72KI/danger-swiftlint) action. Since this action's Docker image already contains Danger-Swift and our standard `Dangerfile` doesn't use any additional plugins, there is appaently no need to create an additional SwiftPM build target that requires Danger.